### PR TITLE
conf: add disable_jobs_from_gui

### DIFF
--- a/jenskipper/cli/push.py
+++ b/jenskipper/cli/push.py
@@ -108,6 +108,9 @@ def _push_jobs(session, jobs_names, progress_bar, base_dir, pipelines,
                                         job_def['context'], pipe_info,
                                         insert_hash=True,
                                         context_overrides=context_overrides)
+        if conf.get(base_dir, ['server', 'disable_jobs_from_gui']):
+            server_conf = jenkins_api.get_job_config(session, job_name)
+            final_conf = jobs.transfuse_disabled_flag(server_conf, final_conf)
         try:
             jenkins_api.push_job_config(
                 session,

--- a/jenskipper/confspec.ini
+++ b/jenskipper/confspec.ini
@@ -1,3 +1,4 @@
 [server]
 location = string(default=None)
 forbid_push = boolean(default=False)
+disable_jobs_from_gui = boolean(default=False)

--- a/jenskipper/jobs.py
+++ b/jenskipper/jobs.py
@@ -168,3 +168,45 @@ def extract_hash_from_text(text):
     else:
         conf_hash = None
     return conf_hash, text
+
+
+def remove_disabled_flag(conf):
+    """
+    Remove the <disabled> tag from *conf* XML.
+    """
+    tree = utils.parse_xml(conf)
+    _do_remove_disabled_flag(tree)
+    return utils.render_xml(tree)
+
+
+def _get_disabled_elt(tree):
+    return tree.find('.//disabled')
+
+
+def _do_remove_disabled_flag(tree):
+    disabled_elt = _get_disabled_elt(tree)
+    if disabled_elt is not None:
+        elt_index = list(tree).index(disabled_elt)
+        tree.remove(disabled_elt)
+    else:
+        elt_index = -1
+    return elt_index
+
+
+def transfuse_disabled_flag(from_conf, to_conf):
+    """
+    Transfuse the <disabled> tag from *from_conf* to *to_conf*.
+
+    This means that we put whatever <disabled> tag there is in *from_conf* in
+    *put_conf*. Leave the <disabled> tag unchanged if it's not present in
+    *from_conf*.
+
+    Return *to_conf* with the transfused tag.
+    """
+    from_tree = utils.parse_xml(from_conf)
+    to_tree = utils.parse_xml(to_conf)
+    transfused_elt = _get_disabled_elt(from_tree)
+    if transfused_elt is not None:
+        elt_index = _do_remove_disabled_flag(to_tree)
+        to_tree.insert(elt_index, transfused_elt)
+    return utils.render_xml(to_tree)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -61,6 +61,29 @@ def test_extract_hash_from_text():
     assert f('foo%s' % h) == ('fff', 'foo')
 
 
+def test_remove_disabled_flag():
+    xml = '<project><disabled>false</disabled></project>'
+    assert jobs.remove_disabled_flag(xml) == '<project />'
+
+
+def test_transfuse_disabled_flag_replace():
+    from_xml = '<project><disabled>false</disabled></project>'
+    to_xml = '<project><disabled>true</disabled></project>'
+    assert jobs.transfuse_disabled_flag(from_xml, to_xml) == from_xml
+
+
+def test_transfuse_disabled_flag_add():
+    from_xml = '<project><disabled>false</disabled></project>'
+    to_xml = '<project></project>'
+    assert jobs.transfuse_disabled_flag(from_xml, to_xml) == from_xml
+
+
+def test_transfuse_disabled_flag_noop():
+    from_xml = '<project></project>'
+    to_xml = '<project><disabled>true</disabled></project>'
+    assert jobs.transfuse_disabled_flag(from_xml, to_xml) == to_xml
+
+
 JOB_WITHOUT_PIPELINE = """<?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>


### PR DESCRIPTION
This flag allows to define the disabled state of jobs from the GUI,
rather than from the conf.

If it's true, the <disabled> tag won't show in XML diffs, and pushes
will let the server value unchanged.